### PR TITLE
[Test] Add benchmarks for queue functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,11 @@ make bench
 
 | Benchmark                                        | Iterations | ns/op | B/op | allocs/op |
 |--------------------------------------------------|------------|------:|-----:|----------:|
-| [LockFreeQ](lock_free_queue_benchmark_test.go)   | 15076060   | 73.92 |   16 |         1 |
+| [LockFreeQ](lock_free_queue_benchmark_test.go)   | 24752019   | 79.73 |   16 |         1 |
+| [NewLockFreeQ](lock_free_queue_benchmark_test.go) | 1000000000 | 0.29 |    0 |         0 |
+| [LockFreeQ_Enqueue](lock_free_queue_benchmark_test.go) | 25041442 | 49.18 |   16 |         1 |
+| [LockFreeQ_Dequeue](lock_free_queue_benchmark_test.go) | 338000521 | 11.14 |    0 |         0 |
+| [LockFreeQ_IsEmpty](lock_free_queue_benchmark_test.go) | 1000000000 | 0.60 |    0 |         0 |
 
 > These benchmarks reflect fast, allocation-free lookups for most retrieval functions, ensuring optimal performance in production environments.
 > Performance benchmarks for the core functions in this library, executed on a 13th Gen Intel i7-1360P (AMD64).

--- a/lock_free_queue_benchmark_test.go
+++ b/lock_free_queue_benchmark_test.go
@@ -4,17 +4,52 @@ import (
 	"testing"
 )
 
-// BenchmarkLockFreeQueue benchmarks the lock-free queue's enqueue and dequeue operations
+// BenchmarkLockFreeQueue benchmarks enqueueing and dequeuing values.
 func BenchmarkLockFreeQueue(b *testing.B) {
 	q := NewLockFreeQ[int]()
-
 	for i := 0; i < b.N; i++ {
 		q.Enqueue(i)
 	}
-
 	for i := 0; i < b.N; i++ {
 		if val := q.Dequeue(); val == nil {
 			b.Errorf("Expected a value, got nil at iteration %d", i)
 		}
+	}
+}
+
+// BenchmarkNewLockFreeQ measures the cost of creating new queue instances.
+func BenchmarkNewLockFreeQ(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NewLockFreeQ[int]()
+	}
+}
+
+// BenchmarkLockFreeQ_Enqueue benchmarks adding items to the queue.
+func BenchmarkLockFreeQ_Enqueue(b *testing.B) {
+	q := NewLockFreeQ[int]()
+	for i := 0; i < b.N; i++ {
+		q.Enqueue(i)
+	}
+}
+
+// BenchmarkLockFreeQ_Dequeue benchmarks removing items from the queue.
+func BenchmarkLockFreeQ_Dequeue(b *testing.B) {
+	q := NewLockFreeQ[int]()
+	for i := 0; i < b.N; i++ {
+		q.Enqueue(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if q.Dequeue() == nil {
+			b.Errorf("expected a value at iteration %d", i)
+		}
+	}
+}
+
+// BenchmarkLockFreeQ_IsEmpty benchmarks the IsEmpty check.
+func BenchmarkLockFreeQ_IsEmpty(b *testing.B) {
+	q := NewLockFreeQ[int]()
+	for i := 0; i < b.N; i++ {
+		_ = q.IsEmpty()
 	}
 }


### PR DESCRIPTION
## What Changed
- Added individual benchmarks for `NewLockFreeQ`, `Enqueue`, `Dequeue`, and `IsEmpty`
- Updated README with benchmark results table

## Why It Was Necessary
Adding missing benchmarks provides insight into performance of each public function and ensures they remain optimized.

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `make govulncheck`
- `make bench`

## Impact / Risk
- No breaking changes expected. Benchmarks do not affect production code.

------
https://chatgpt.com/codex/tasks/task_e_6864a86bec088321a2dfd3f4cd2521b0