### PR TITLE
[Fix] Minor doc edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,13 +304,13 @@ make bench
 
 ### Benchmark Results
 
-| Benchmark                                        | Iterations | ns/op | B/op | allocs/op |
-|--------------------------------------------------|------------|------:|-----:|----------:|
-| [LockFreeQ](lock_free_queue_benchmark_test.go)   | 24752019   | 79.73 |   16 |         1 |
-| [NewLockFreeQ](lock_free_queue_benchmark_test.go) | 1000000000 | 0.29 |    0 |         0 |
-| [LockFreeQ_Enqueue](lock_free_queue_benchmark_test.go) | 25041442 | 49.18 |   16 |         1 |
-| [LockFreeQ_Dequeue](lock_free_queue_benchmark_test.go) | 338000521 | 11.14 |    0 |         0 |
-| [LockFreeQ_IsEmpty](lock_free_queue_benchmark_test.go) | 1000000000 | 0.60 |    0 |         0 |
+| Benchmark                                             | Iterations | ns/op | B/op | allocs/op |
+|-------------------------------------------------------|------------|------:|-----:|----------:|
+| [LockFreeQueue](lock_free_queue_benchmark_test.go)    | 24752019   | 79.73 |   16 |         1 |
+| [NewLockFreeQ](lock_free_queue_benchmark_test.go)     | 1000000000 |  0.29 |    0 |         0 |
+| [LockFreeQEnqueue](lock_free_queue_benchmark_test.go) | 25041442   | 49.18 |   16 |         1 |
+| [LockFreeQDequeue](lock_free_queue_benchmark_test.go) | 338000521  | 11.14 |    0 |         0 |
+| [LockFreeQIsEmpty](lock_free_queue_benchmark_test.go) | 1000000000 |  0.60 |    0 |         0 |
 
 > These benchmarks reflect fast, allocation-free lookups for most retrieval functions, ensuring optimal performance in production environments.
 > Performance benchmarks for the core functions in this library, executed on a 13th Gen Intel i7-1360P (AMD64).

--- a/lock_free_queue.go
+++ b/lock_free_queue.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 )
 
+// node represents a single element in the lock-free queue.
 type node[T any] struct {
 	value T
 	next  atomic.Pointer[node[T]]


### PR DESCRIPTION
This pull request includes updates to improve clarity and maintainability in the benchmark results and adds documentation for a key data structure in the lock-free queue implementation.

### Documentation improvements:

* [`lock_free_queue.go`](diffhunk://#diff-31128f58a28605177913910a9c0b91f5089e6a8ddbb956ca9741c01585d98ae6R9): Added a comment to document the `node` struct, explaining that it represents a single element in the lock-free queue.

### Benchmark result updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308-R313): Updated benchmark table entries to use more consistent naming conventions (e.g., `LockFreeQEnqueue`, `LockFreeQDequeue`, `LockFreeQIsEmpty`) for improved readability and alignment with code identifiers.