### PR TITLE
[Docs] Remove install-template command from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ govulncheck-install   ## Install govulncheck
 help                  ## Display this help message
 install-go            ## Install using go install with specific version
 install-releaser      ## Install GoReleaser
-install-template      ## Kick-start a fresh copy of go-lockfree-queue (run once!)
 install               ## Install the application binary
 lint                  ## Run the golangci-lint application (install if not found)
 release-snap          ## Build snapshot binaries


### PR DESCRIPTION
## What Changed
- removed obsolete `install-template` entry from README's make commands list

## Why It Was Necessary
- the command no longer exists in the Makefile, so README should not reference it

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- documentation only; no runtime changes

------
https://chatgpt.com/codex/tasks/task_e_6866b721440883219dc5993fffcd3705