### PR TITLE
[Repo] Update CODEOWNERS for configuration files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 
 # GitHub Actions workflows
 .github/workflows/* @mrz1836
+.github/.env.shared @mrz1836
 
 # Documentation files
 *.md @mrz1836
@@ -19,3 +20,13 @@ Makefile @mrz1836
 # Go module dependencies
 go.mod @mrz1836
 go.sum @mrz1836
+
+# AI Config Files
+.github/AGENTS.md @mrz1836
+.cursorrules @mrz1836
+.github/CLAUDE.md @mrz1836
+sweep.yml @mrz1836
+
+# Repository configuration
+.github/labels.yml @mrz1836
+.github/dependabot.yml @mrz1836


### PR DESCRIPTION
## What Changed
- added `.github/.env.shared` entry under GitHub Actions workflows
- created **AI Config Files** section with relevant entries
- added **Repository configuration** section for labels and Dependabot files

## Why It Was Necessary
- keep ownership metadata complete so tooling can notify maintainers

## Testing Performed
- `make lint`
- `make test`
- `make test-fuzz`

## Impact / Risk
- low; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_6878f31037ec83219e34631db7add2e8