### PR TITLE
[CI] Remove nonexistent labels from update workflows

### DIFF
--- a/.github/.env.shared
+++ b/.github/.env.shared
@@ -84,7 +84,7 @@ PIP_DIRECTORY=.github/pip                                            # Directory
 UPDATE_PYTHON_DEPENDENCIES_SCHEDULE_UPDATE_MAIN=true                 # Default: Update main requirements on scheduled runs
 UPDATE_PYTHON_DEPENDENCIES_SCHEDULE_UPDATE_PIP_TOOLS=true            # Default: Update pip-tools requirements on scheduled runs
 UPDATE_PYTHON_DEPENDENCIES_SCHEDULE_CREATE_PR=true                   # Default: Create PR on scheduled runs
-UPDATE_PYTHON_DEPENDENCIES_PR_LABELS=dependencies,chore,automated,python  # Labels to apply to PRs (comma-separated)
+UPDATE_PYTHON_DEPENDENCIES_PR_LABELS=dependencies,chore  # Labels to apply to PRs (comma-separated)
 UPDATE_PYTHON_DEPENDENCIES_PR_ASSIGNEE=mrz1836                       # Default assignee for PRs
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -93,7 +93,7 @@ UPDATE_PYTHON_DEPENDENCIES_PR_ASSIGNEE=mrz1836                       # Default a
 UPDATE_PRE_COMMIT_HOOKS_BRANCH=chore/update-pre-commit-hooks      # Branch name for pre-commit update PRs
 PRE_COMMIT_CONFIG_FILE=.pre-commit-config.yaml                    # Path to the pre-commit config file
 UPDATE_PRE_COMMIT_HOOKS_SCHEDULE_CREATE_PR=true                   # Default: Create PR on scheduled runs
-UPDATE_PRE_COMMIT_HOOKS_PR_LABELS=dependencies,chore,automated,pre-commit  # Labels to apply to PRs (comma-separated)
+UPDATE_PRE_COMMIT_HOOKS_PR_LABELS=dependencies,chore  # Labels to apply to PRs (comma-separated)
 UPDATE_PRE_COMMIT_HOOKS_PR_ASSIGNEE=mrz1836                       # Default assignee for PRs
 UPDATE_PRE_COMMIT_HOOKS_TEST_ON_UPDATE=true                       # Default: Test hooks after update
 


### PR DESCRIPTION
## What Changed
- removed `automated` and tool-specific labels from environment config

## Why It Was Necessary
- update workflows failed when `gh pr create` attempted to apply labels that do not exist in this repository

## Testing Performed
- `go test ./...`

## Impact / Risk
- workflows will run without label errors


------
https://chatgpt.com/codex/tasks/task_e_687e5242b6ac832191db482994086b50