### PR TITLE
[Sync] Update project files from source repository (55c7f74)

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -286,7 +286,9 @@ jobs:
             // Get latest review per user
             const latestReviews = {};
             reviews.forEach(review => {
-              const userId = review.user.id;
+              // review.user is null for deleted accounts - fall back to a unique
+              // key so the review still counts instead of throwing.
+              const userId = review.user?.id ?? `deleted-user:${review.id}`;
               if (!latestReviews[userId] || review.submitted_at > latestReviews[userId].submitted_at) {
                 latestReviews[userId] = review;
               }

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -57,7 +57,7 @@ concurrency:
 # Note: Configuration variables are loaded from modular .github/env/ files
 
 jobs:
-  # -------------------------------------------------g---------------------------------
+  # ----------------------------------------------------------------------------------
   # Dependabot processing (single consolidated job)
   #
   # Workflow phases (each preserved as a step):
@@ -787,7 +787,9 @@ jobs:
             });
             const latestReviews = {};
             reviews.forEach(review => {
-              const userId = review.user.id;
+              // review.user is null for deleted accounts - fall back to a unique
+              // key so the review still counts instead of throwing.
+              const userId = review.user?.id ?? `deleted-user:${review.id}`;
               if (!latestReviews[userId] || review.submitted_at > latestReviews[userId].submitted_at) {
                 latestReviews[userId] = review;
               }

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What Changed

* Updated CodeQL actions from commit hash `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (v4.37.3) to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (v4.37.4) across four workflow steps: `init`, `autobuild`, `analyze`, and `upload-sarif`
* Added null-safety checks for `review.user` in auto-merge workflows to handle deleted GitHub accounts, falling back to `deleted-user:${review.id}` as a unique key when user is null
* Fixed a formatting issue in a comment line in the dependabot-auto-merge workflow (corrected separator line alignment)

## Why It Was Necessary

* CodeQL action updates ensure the latest security scanning capabilities and bug fixes are applied to the CI/CD pipeline
* The null-safety fix prevents workflow failures when processing pull request reviews from deleted GitHub accounts, which would previously throw errors when accessing `review.user.id`
* Maintaining up-to-date GitHub Actions improves security posture and ensures compatibility with the latest GitHub features

## Testing Performed

* CodeQL workflow updates can be verified by monitoring the next scheduled security scans to ensure they complete successfully
* The review user null-safety fix should be validated by testing scenarios where deleted users have submitted reviews on pull requests
* Existing CI/CD pipelines should continue to function normally with the updated action versions and defensive coding improvements

## Impact / Risk

* **Breaking Change**: None - these are backward-compatible updates to GitHub Actions and defensive code improvements
* **Risk**: Low - CodeQL version bump is a minor version increment, and the null-safety check only affects edge cases with deleted user accounts
* **Performance**: No impact expected - changes are to action versions and error handling logic only

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-sdks
  name: bsv-blockchain-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 4
  files_with_original_content: 4
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 55c7f745fe5ca530414b439da64f611340618a4f
  target_repo: bsv-blockchain/go-lockfree-queue
  sync_commit: be269a025685812f2a13058dd90794df406c2af8
  sync_time: 2026-08-03T15:58:00-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 264
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 976
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 542
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 846
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 565
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 964
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 4
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1674
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 450
performance:
  total_files: 102
-->
